### PR TITLE
add missing executor

### DIFF
--- a/pkg/cmd/scaffold.go
+++ b/pkg/cmd/scaffold.go
@@ -35,6 +35,7 @@ metadata:
 spec:
   image: "{{ .Image }}"
   replicas: {{ .Replicas }}
+  executor: containerd-shim-spin
 {{- if .RuntimeConfig }}
   runtimeConfig:
     loadFromSecret: {{ .Name }}-runtime-config

--- a/pkg/cmd/testdata/scaffold_image.yml
+++ b/pkg/cmd/testdata/scaffold_image.yml
@@ -5,3 +5,4 @@ metadata:
 spec:
   image: "ghcr.io/foo/example-app:v0.1.0"
   replicas: 2
+  executor: containerd-shim-spin

--- a/pkg/cmd/testdata/scaffold_runtime_config.yml
+++ b/pkg/cmd/testdata/scaffold_runtime_config.yml
@@ -5,6 +5,7 @@ metadata:
 spec:
   image: "ghcr.io/foo/example-app:v0.1.0"
   replicas: 2
+  executor: containerd-shim-spin
   runtimeConfig:
     loadFromSecret: example-app-runtime-config
 ---


### PR DESCRIPTION
```
><> spin k8s scaffold --from bacongobbler/hello-rust:latest | kubectl apply -f -
The SpinApp "hello-rust" is invalid: spec.executor: Required value
```