### PR TITLE
Add name flag to scaffold Command

### DIFF
--- a/pkg/cmd/deploy.go
+++ b/pkg/cmd/deploy.go
@@ -13,9 +13,10 @@ import (
 )
 
 var (
-	artifact string
-	replicas int32
-	dryRun   bool
+	artifact   string
+	replicas   int32
+	dryRun     bool
+	customName string
 )
 
 var deployCmd = &cobra.Command{
@@ -23,7 +24,7 @@ var deployCmd = &cobra.Command{
 	Short:  "Deploy application to Kubernetes",
 	Hidden: isExperimentalFlagNotSet,
 	RunE: func(_ *cobra.Command, _ []string) error {
-		name, err := getNameFromImageReference(artifact)
+		name, err := getSpinAppName(artifact, customName)
 		if err != nil {
 			return err
 		}
@@ -65,7 +66,7 @@ func init() {
 	deployCmd.Flags().BoolVar(&dryRun, "dry-run", false, "only print the kubernetes manifest without deploying")
 	deployCmd.Flags().Int32VarP(&replicas, "replicas", "r", 2, "Number of replicas for the application")
 	deployCmd.Flags().StringVarP(&artifact, "from", "f", "", "Reference in the registry of the application")
-
+	deployCmd.Flags().StringVarP(&customName, "name", "", "", "Overwrite the generated name of the application")
 	if err := deployCmd.MarkFlagRequired("from"); err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/cmd/scaffold_test.go
+++ b/pkg/cmd/scaffold_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -110,6 +111,16 @@ func TestScaffoldOutput(t *testing.T) {
 				},
 			},
 			expected: "components.yml",
+		},
+		{
+			name: "overwrite name",
+			opts: ScaffoldOptions{
+				from:     "ghcr.io/foo/example-app:v0.1.0",
+				replicas: 2,
+				executor: "containerd-shim-spin",
+				name:     "my-custom-name",
+			},
+			expected: "overwrite_name.yml",
 		},
 	}
 
@@ -304,6 +315,22 @@ func TestFlagValidation(t *testing.T) {
 				targetCPUUtilizationPercentage: 1,
 			},
 			expectedError: "target memory utilization percentage (0) must be between 1 and 100",
+		},
+		{
+			name: "must provide valid DNS subdomain name",
+			opts: ScaffoldOptions{
+				from: "ghcr.io/foo/example-app:v0.1.0",
+				name: "my*app",
+			},
+			expectedError: "invalid name provided. Must be a valid DNS subdomain name and not more than 253 chars",
+		},
+		{
+			name: "must provide valid DNS subdomain name 2",
+			opts: ScaffoldOptions{
+				from: "ghcr.io/foo/example-app:v0.1.0",
+				name: strings.Repeat("a", 254),
+			},
+			expectedError: "invalid name provided. Must be a valid DNS subdomain name and not more than 253 chars",
 		},
 	}
 

--- a/pkg/cmd/scaffold_test.go
+++ b/pkg/cmd/scaffold_test.go
@@ -158,42 +158,59 @@ func TestValidateImageReference_ValidImageReference(t *testing.T) {
 	}
 }
 
-func TestGetNameFromImageReference(t *testing.T) {
+func TestGetSpinAppName(t *testing.T) {
 	testCases := []struct {
-		reference string
-		name      string
+		reference  string
+		customName string
+		name       string
 	}{
 		{
-			reference: "bacongobbler/hello-rust",
-			name:      "hello-rust",
+			reference:  "bacongobbler/hello-rust",
+			customName: "",
+			name:       "hello-rust",
 		}, {
-			reference: "bacongobbler/hello-rust:v1.0.0",
-			name:      "hello-rust",
+			reference:  "bacongobbler/hello-rust:v1.0.0",
+			customName: "",
+			name:       "hello-rust",
 		}, {
 
-			reference: "ghcr.io/bacongobbler/hello-rust",
-			name:      "hello-rust",
+			reference:  "ghcr.io/bacongobbler/hello-rust",
+			customName: "",
+			name:       "hello-rust",
 		}, {
-			reference: "ghcr.io/bacongobbler/hello-rust:v1.0.0",
-			name:      "hello-rust",
+			reference:  "ghcr.io/bacongobbler/hello-rust:v1.0.0",
+			customName: "",
+			name:       "hello-rust",
 		}, {
-			reference: "ghcr.io/spinkube/spinkube/runtime-class-manager:v1",
-			name:      "runtime-class-manager",
+			reference:  "ghcr.io/spinkube/spinkube/runtime-class-manager:v1",
+			customName: "",
+			name:       "runtime-class-manager",
 		}, {
-			reference: "nginx:latest",
-			name:      "nginx",
+			reference:  "nginx:latest",
+			customName: "",
+			name:       "nginx",
 		}, {
-			reference: "nginx",
-			name:      "nginx",
+			reference:  "nginx:latest",
+			customName: "web-server",
+			name:       "web-server",
 		}, {
-			reference: "ttl.sh/hello-spinkube@sha256:cc4b191d11728b4e9e024308f0c03aded893da2002403943adc9deb8c4ca1644",
-			name:      "hello-spinkube",
+			reference:  "nginx",
+			customName: "",
+			name:       "nginx",
+		}, {
+			reference:  "ttl.sh/hello-spinkube@sha256:cc4b191d11728b4e9e024308f0c03aded893da2002403943adc9deb8c4ca1644",
+			customName: "",
+			name:       "hello-spinkube",
+		}, {
+			reference:  "ttl.sh/hello-spinkube@sha256:cc4b191d11728b4e9e024308f0c03aded893da2002403943adc9deb8c4ca1644",
+			customName: "hi-spinkube",
+			name:       "hi-spinkube",
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.reference, func(t *testing.T) {
-			actualName, err := getNameFromImageReference(tc.reference)
+			actualName, err := getSpinAppName(tc.reference, tc.customName)
 			require.Nil(t, err)
 			require.Equal(t, tc.name, actualName, "Expected image name from reference")
 		})

--- a/pkg/cmd/testdata/overwrite_name.yml
+++ b/pkg/cmd/testdata/overwrite_name.yml
@@ -1,0 +1,8 @@
+apiVersion: core.spinkube.dev/v1alpha1
+kind: SpinApp
+metadata:
+  name: my-custom-name
+spec:
+  image: "ghcr.io/foo/example-app:v0.1.0"
+  executor: containerd-shim-spin
+  replicas: 2


### PR DESCRIPTION
This PR adds an optional `name` flag to the `scaffold` command.

## Motivation

As a user I want to specify a custom name when scaffolding a Kubernetes Deployment manifest for my Spin App. 

## Behavior

The `name` flag is optional. By default the name of the Spin App is generated using the provided OCI artifact reference (as it was before). If the `--name` flag is specified, its value is validated and used for scaffolding.

### Validation

Only valid DNS subdomain names with less than 254 chars are considered valid. If an invalid value is provided, execution is terminated and a corresponding error message is presented to the user