### PR TITLE
feat: add service account name to scaffold command

### DIFF
--- a/pkg/cmd/scaffold.go
+++ b/pkg/cmd/scaffold.go
@@ -72,6 +72,7 @@ spec:
 {{- if .AzureWorkloadIdentity }}
   podLabels:
     azure.workload.identity/use: "true"
+{{- end }}
 {{- if .ServiceAccountName }}
   serviceAccountName: {{ .ServiceAccountName }}
 {{- end }}

--- a/pkg/cmd/scaffold.go
+++ b/pkg/cmd/scaffold.go
@@ -341,7 +341,7 @@ func init() {
 	scaffoldCmd.Flags().StringVar(&scaffoldOpts.memoryLimit, "memory-limit", "", "The maximum amount of memory the application is allowed to use")
 	scaffoldCmd.Flags().StringVar(&scaffoldOpts.memoryRequest, "memory-request", "", "The amount of memory requested by the application. Used to determine which node the application will run on")
 	scaffoldCmd.Flags().BoolVar(&scaffoldOpts.azureWorkloadIdentity, "azure-identity", false, "Enable Azure Workload Identity for the application")
-	scaffoldCmd.Flags().StringVar(&scaffoldOpts.serviceAccountName, "service-account-name", "default", "The name of the service account to use for the application")
+	scaffoldCmd.Flags().StringVar(&scaffoldOpts.serviceAccountName, "service-account-name", "", "The name of the service account to use for the application")
 	scaffoldCmd.Flags().StringVarP(&scaffoldOpts.from, "from", "f", "", "Reference in the registry of the application")
 	scaffoldCmd.Flags().StringVarP(&scaffoldOpts.output, "out", "o", "", "Path to file to write manifest yaml")
 	scaffoldCmd.Flags().StringVarP(&scaffoldOpts.configfile, "runtime-config-file", "c", "", "Path to runtime config file")

--- a/pkg/cmd/scaffold.go
+++ b/pkg/cmd/scaffold.go
@@ -27,6 +27,7 @@ type ScaffoldOptions struct {
 	memoryRequest                     string
 	output                            string
 	replicas                          int32
+	serviceAccountName                string
 	targetCPUUtilizationPercentage    int32
 	targetMemoryUtilizationPercentage int32
 	variables                         map[string]string
@@ -49,6 +50,7 @@ type appConfig struct {
 	Name                              string
 	Replicas                          int32
 	RuntimeConfig                     string
+	ServiceAccountName                string
 	TargetCPUUtilizationPercentage    int32
 	TargetMemoryUtilizationPercentage int32
 	Variables                         map[string]string
@@ -70,6 +72,8 @@ spec:
 {{- if .AzureWorkloadIdentity }}
   podLabels:
     azure.workload.identity/use: "true"
+{{- if .ServiceAccountName }}
+  serviceAccountName: {{ .ServiceAccountName }}
 {{- end }}
 {{- if .Variables }}
   variables:
@@ -279,6 +283,7 @@ func scaffold(opts ScaffoldOptions) ([]byte, error) {
 		Variables:                         opts.variables,
 		Components:                        opts.components,
 		AzureWorkloadIdentity:             opts.azureWorkloadIdentity,
+		ServiceAccountName:                opts.serviceAccountName,
 	}
 
 	if opts.configfile != "" {
@@ -335,6 +340,7 @@ func init() {
 	scaffoldCmd.Flags().StringVar(&scaffoldOpts.memoryLimit, "memory-limit", "", "The maximum amount of memory the application is allowed to use")
 	scaffoldCmd.Flags().StringVar(&scaffoldOpts.memoryRequest, "memory-request", "", "The amount of memory requested by the application. Used to determine which node the application will run on")
 	scaffoldCmd.Flags().BoolVar(&scaffoldOpts.azureWorkloadIdentity, "azure-identity", false, "Enable Azure Workload Identity for the application")
+	scaffoldCmd.Flags().StringVar(&scaffoldOpts.serviceAccountName, "service-account-name", "default", "The name of the service account to use for the application")
 	scaffoldCmd.Flags().StringVarP(&scaffoldOpts.from, "from", "f", "", "Reference in the registry of the application")
 	scaffoldCmd.Flags().StringVarP(&scaffoldOpts.output, "out", "o", "", "Path to file to write manifest yaml")
 	scaffoldCmd.Flags().StringVarP(&scaffoldOpts.configfile, "runtime-config-file", "c", "", "Path to runtime config file")

--- a/pkg/cmd/scaffold_test.go
+++ b/pkg/cmd/scaffold_test.go
@@ -76,6 +76,16 @@ func TestScaffoldOutput(t *testing.T) {
 			expected: "service_account_name.yml",
 		},
 		{
+			name: "service account name is not provided",
+			opts: ScaffoldOptions{
+				from:               "ghcr.io/foo/example-app:v0.1.0",
+				replicas:           2,
+				executor:           "containerd-shim-spin",
+				serviceAccountName: "",
+			},
+			expected: "no_service_account_name.yml",
+		},
+		{
 			name: "service account with HPA autoscaler",
 			opts: ScaffoldOptions{
 				from:                              "ghcr.io/foo/example-app:v0.1.0",

--- a/pkg/cmd/scaffold_test.go
+++ b/pkg/cmd/scaffold_test.go
@@ -66,6 +66,32 @@ func TestScaffoldOutput(t *testing.T) {
 			expected: "multiple_image_secrets.yml",
 		},
 		{
+			name: "service account name is provided",
+			opts: ScaffoldOptions{
+				from:               "ghcr.io/foo/example-app:v0.1.0",
+				replicas:           2,
+				executor:           "containerd-shim-spin",
+				serviceAccountName: "my-service-account",
+			},
+			expected: "service_account_name.yml",
+		},
+		{
+			name: "service account with HPA autoscaler",
+			opts: ScaffoldOptions{
+				from:                              "ghcr.io/foo/example-app:v0.1.0",
+				executor:                          "containerd-shim-spin",
+				autoscaler:                        "hpa",
+				cpuLimit:                          "100m",
+				memoryLimit:                       "128Mi",
+				replicas:                          2,
+				maxReplicas:                       3,
+				targetCPUUtilizationPercentage:    60,
+				targetMemoryUtilizationPercentage: 60,
+				serviceAccountName:                "my-service-account",
+			},
+			expected: "hpa_service_account.yml",
+		},
+		{
 			name: "HPA autoscaler support",
 			opts: ScaffoldOptions{
 				from:                              "ghcr.io/foo/example-app:v0.1.0",

--- a/pkg/cmd/testdata/hpa_service_account.yml
+++ b/pkg/cmd/testdata/hpa_service_account.yml
@@ -1,0 +1,38 @@
+apiVersion: core.spinkube.dev/v1alpha1
+kind: SpinApp
+metadata:
+  name: example-app
+spec:
+  image: "ghcr.io/foo/example-app:v0.1.0"
+  executor: containerd-shim-spin
+  enableAutoscaling: true
+  serviceAccountName: my-service-account
+  resources:
+    limits:
+      cpu: 100m
+      memory: 128Mi
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: example-app-autoscaler
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: example-app
+  minReplicas: 2
+  maxReplicas: 3
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 60
+  - type: Resource
+    resource:
+      name: memory
+      target:
+        type: Utilization
+        averageUtilization: 60

--- a/pkg/cmd/testdata/no_service_account_name.yml
+++ b/pkg/cmd/testdata/no_service_account_name.yml
@@ -1,0 +1,8 @@
+apiVersion: core.spinkube.dev/v1alpha1
+kind: SpinApp
+metadata:
+  name: example-app
+spec:
+  image: "ghcr.io/foo/example-app:v0.1.0"
+  executor: containerd-shim-spin
+  replicas: 2

--- a/pkg/cmd/testdata/service_account_name.yml
+++ b/pkg/cmd/testdata/service_account_name.yml
@@ -1,0 +1,9 @@
+apiVersion: core.spinkube.dev/v1alpha1
+kind: SpinApp
+metadata:
+  name: example-app
+spec:
+  image: "ghcr.io/foo/example-app:v0.1.0"
+  executor: containerd-shim-spin
+  replicas: 2
+  serviceAccountName: my-service-account


### PR DESCRIPTION
Add a new flag `--service-account-name` to the `spin-plugin-kube scaffold` command
to allow specifying the service account name for the SpinApp CRD.

The default service account name is `default`.

Signed-off-by: Jiaxiao (mossaka) Zhou <duibao55328@gmail.com>
