### PR TITLE
feat: add azure workload identity support in scaffold command

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,7 +23,7 @@ jobs:
           go-version: stable
           cache: false
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v4
+        uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.61.0
+          version: v1.64.6
           args: --timeout 3m

--- a/pkg/cmd/scaffold.go
+++ b/pkg/cmd/scaffold.go
@@ -15,6 +15,7 @@ import (
 
 type ScaffoldOptions struct {
 	autoscaler                        string
+	azureWorkloadIdentity             bool
 	configfile                        string
 	cpuLimit                          string
 	cpuRequest                        string
@@ -36,6 +37,7 @@ var scaffoldOpts = ScaffoldOptions{}
 
 type appConfig struct {
 	Autoscaler                        string
+	AzureWorkloadIdentity             bool
 	CPULimit                          string
 	CPURequest                        string
 	Executor                          string
@@ -65,6 +67,10 @@ spec:
 {{- else }}
   replicas: {{ .Replicas }}
 {{- end}}
+{{- if .AzureWorkloadIdentity }}
+  podLabels:
+    azure.workload.identity/use: "true"
+{{- end }}
 {{- if .Variables }}
   variables:
 {{- range $key, $value := .Variables }}
@@ -272,6 +278,7 @@ func scaffold(opts ScaffoldOptions) ([]byte, error) {
 		ImagePullSecrets:                  opts.imagePullSecrets,
 		Variables:                         opts.variables,
 		Components:                        opts.components,
+		AzureWorkloadIdentity:             opts.azureWorkloadIdentity,
 	}
 
 	if opts.configfile != "" {
@@ -327,6 +334,7 @@ func init() {
 	scaffoldCmd.Flags().StringVar(&scaffoldOpts.cpuRequest, "cpu-request", "", "The amount of CPU resource units requested by the application. Used to determine which node the application will run on")
 	scaffoldCmd.Flags().StringVar(&scaffoldOpts.memoryLimit, "memory-limit", "", "The maximum amount of memory the application is allowed to use")
 	scaffoldCmd.Flags().StringVar(&scaffoldOpts.memoryRequest, "memory-request", "", "The amount of memory requested by the application. Used to determine which node the application will run on")
+	scaffoldCmd.Flags().BoolVar(&scaffoldOpts.azureWorkloadIdentity, "azure-identity", false, "Enable Azure Workload Identity for the application")
 	scaffoldCmd.Flags().StringVarP(&scaffoldOpts.from, "from", "f", "", "Reference in the registry of the application")
 	scaffoldCmd.Flags().StringVarP(&scaffoldOpts.output, "out", "o", "", "Path to file to write manifest yaml")
 	scaffoldCmd.Flags().StringVarP(&scaffoldOpts.configfile, "runtime-config-file", "c", "", "Path to runtime config file")

--- a/pkg/cmd/scaffold_test.go
+++ b/pkg/cmd/scaffold_test.go
@@ -34,6 +34,16 @@ func TestScaffoldOutput(t *testing.T) {
 			expected: "scaffold_runtime_config.yml",
 		},
 		{
+			name: "azure identity is enabled",
+			opts: ScaffoldOptions{
+				from:                  "ghcr.io/foo/example-app:v0.1.0",
+				replicas:              2,
+				executor:              "containerd-shim-spin",
+				azureWorkloadIdentity: true,
+			},
+			expected: "azure_workload_identity.yml",
+		},
+		{
 			name: "one image pull secret is provided",
 			opts: ScaffoldOptions{
 				from:             "ghcr.io/foo/example-app:v0.1.0",

--- a/pkg/cmd/testdata/azure_workload_identity.yml
+++ b/pkg/cmd/testdata/azure_workload_identity.yml
@@ -1,0 +1,10 @@
+apiVersion: core.spinkube.dev/v1alpha1
+kind: SpinApp
+metadata:
+  name: example-app
+spec:
+  image: "ghcr.io/foo/example-app:v0.1.0"
+  executor: containerd-shim-spin
+  replicas: 2
+  podLabels:
+    azure.workload.identity/use: "true"


### PR DESCRIPTION
This commit adds a `azure-workload-identity` flag to the `spin-plugin-kube scaffold` command.

When this flag is set, the scaffold command will add the `azure.workload.identity/use: "true"` pod label to the SpinApp CRD.

Signed-off-by: Jiaxiao (mossaka) Zhou <duibao55328@gmail.com>
