### PR TITLE
fix: change the url in spin-plugin template file

### DIFF
--- a/contrib/spin-plugin.json.tmpl
+++ b/contrib/spin-plugin.json.tmpl
@@ -1,7 +1,7 @@
 {
   "name": "kube",
   "description": "A plugin to manage spin apps",
-  "homepage": "https://github.com/spinkube/spin-plugin-kube",
+  "homepage": "https://github.com/spinframework/spin-plugin-kube",
   "version": "{{ Version }}",
   "spinCompatibility": ">=2.3.1",
   "license": "Apache-2.0",
@@ -9,32 +9,32 @@
     {
       "os": "linux",
       "arch": "amd64",
-      {{#addURLAndSha}}https://github.com/spinkube/spin-plugin-kube/releases/download/{{ TagName }}/spin-plugin-kube-{{ Version }}-linux-amd64.tar.gz{{/addURLAndSha}}
+      {{#addURLAndSha}}https://github.com/spinframework/spin-plugin-kube/releases/download/{{ TagName }}/spin-plugin-kube-{{ Version }}-linux-amd64.tar.gz{{/addURLAndSha}}
     },
     {
       "os": "linux",
       "arch": "aarch64",
-      {{#addURLAndSha}}https://github.com/spinkube/spin-plugin-kube/releases/download/{{ TagName }}/spin-plugin-kube-{{ Version }}-linux-arm64.tar.gz{{/addURLAndSha}}
+      {{#addURLAndSha}}https://github.com/spinframework/spin-plugin-kube/releases/download/{{ TagName }}/spin-plugin-kube-{{ Version }}-linux-arm64.tar.gz{{/addURLAndSha}}
     },
     {
       "os": "macos",
       "arch": "aarch64",
-      {{#addURLAndSha}}https://github.com/spinkube/spin-plugin-kube/releases/download/{{ TagName }}/spin-plugin-kube-{{ Version }}-darwin-arm64.tar.gz{{/addURLAndSha}}
+      {{#addURLAndSha}}https://github.com/spinframework/spin-plugin-kube/releases/download/{{ TagName }}/spin-plugin-kube-{{ Version }}-darwin-arm64.tar.gz{{/addURLAndSha}}
     },
     {
       "os": "macos",
       "arch": "amd64",
-      {{#addURLAndSha}}https://github.com/spinkube/spin-plugin-kube/releases/download/{{ TagName }}/spin-plugin-kube-{{ Version }}-darwin-amd64.tar.gz{{/addURLAndSha}}
+      {{#addURLAndSha}}https://github.com/spinframework/spin-plugin-kube/releases/download/{{ TagName }}/spin-plugin-kube-{{ Version }}-darwin-amd64.tar.gz{{/addURLAndSha}}
     },
     {
       "os": "windows",
       "arch": "amd64",
-      {{#addURLAndSha}}https://github.com/spinkube/spin-plugin-kube/releases/download/{{ TagName }}/spin-plugin-kube-{{ Version }}-windows-amd64.tar.gz{{/addURLAndSha}}
+      {{#addURLAndSha}}https://github.com/spinframework/spin-plugin-kube/releases/download/{{ TagName }}/spin-plugin-kube-{{ Version }}-windows-amd64.tar.gz{{/addURLAndSha}}
     },
     {
       "os": "windows",
       "arch": "aarch64",
-      {{#addURLAndSha}}https://github.com/spinkube/spin-plugin-kube/releases/download/{{ TagName }}/spin-plugin-kube-{{ Version }}-windows-arm64.tar.gz{{/addURLAndSha}}
+      {{#addURLAndSha}}https://github.com/spinframework/spin-plugin-kube/releases/download/{{ TagName }}/spin-plugin-kube-{{ Version }}-windows-arm64.tar.gz{{/addURLAndSha}}
     }
   ]
 }


### PR DESCRIPTION
The spin plugin releaser use download url as key for storing sha256 of the assets. With the move, the actual release assets point to `spinframework` org, but the template is still using `spinkube` for the org. 

This causes the sha256 in the rendered template to be undefined. Changing this to `spinframework` should fix the release process.