### PR TITLE
Stabilize `deploy` command

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,5 +25,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.5.0
+          version: v2.13.2
           args: --timeout 3m

--- a/pkg/cmd/deploy.go
+++ b/pkg/cmd/deploy.go
@@ -13,15 +13,15 @@ import (
 )
 
 var (
-	artifact string
-	replicas int32
-	dryRun   bool
+	artifact        string
+	replicas        int32
+	dryRun          bool
+	spinAppExecutor string
 )
 
 var deployCmd = &cobra.Command{
-	Use:    "deploy",
-	Short:  "Deploy application to Kubernetes",
-	Hidden: isExperimentalFlagNotSet,
+	Use:   "deploy",
+	Short: "Deploy application to Kubernetes",
 	RunE: func(_ *cobra.Command, _ []string) error {
 		name, err := getNameFromImageReference(artifact)
 		if err != nil {
@@ -40,7 +40,7 @@ var deployCmd = &cobra.Command{
 			Spec: spinv1alpha1.SpinAppSpec{
 				Replicas: replicas,
 				Image:    artifact,
-				Executor: "containerd-shim-spin",
+				Executor: spinAppExecutor,
 			},
 		}
 
@@ -56,15 +56,16 @@ var deployCmd = &cobra.Command{
 			return err
 		}
 
-		fmt.Printf("spinapp.spin.fermyon.com/%s configured\n", name)
+		fmt.Printf("spinapp.core.spinkube.dev/%s created\n", name)
 		return nil
 	},
 }
 
 func init() {
-	deployCmd.Flags().BoolVar(&dryRun, "dry-run", false, "only print the kubernetes manifest without deploying")
 	deployCmd.Flags().Int32VarP(&replicas, "replicas", "r", 2, "Number of replicas for the application")
 	deployCmd.Flags().StringVarP(&artifact, "from", "f", "", "Reference in the registry of the application")
+	deployCmd.Flags().StringVar(&spinAppExecutor, "executor", default_spin_app_executor, "The executor used to run the application")
+	deployCmd.Flags().BoolVar(&dryRun, "dry-run", false, "only print the kubernetes manifest without deploying")
 
 	if err := deployCmd.MarkFlagRequired("from"); err != nil {
 		log.Fatal(err)

--- a/pkg/cmd/deploy.go
+++ b/pkg/cmd/deploy.go
@@ -64,7 +64,7 @@ var deployCmd = &cobra.Command{
 func init() {
 	deployCmd.Flags().Int32VarP(&replicas, "replicas", "r", 2, "Number of replicas for the application")
 	deployCmd.Flags().StringVarP(&artifact, "from", "f", "", "Reference in the registry of the application")
-	deployCmd.Flags().StringVar(&spinAppExecutor, "executor", default_spin_app_executor, "The executor used to run the application")
+	deployCmd.Flags().StringVar(&spinAppExecutor, "executor", defaultSpinAppExecutor, "The executor used to run the application")
 	deployCmd.Flags().BoolVar(&dryRun, "dry-run", false, "only print the kubernetes manifest without deploying")
 
 	if err := deployCmd.MarkFlagRequired("from"); err != nil {

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -14,7 +14,7 @@ import (
 
 // global constants
 const (
-	default_spin_app_executor = "containerd-shim-spin"
+	defaultSpinAppExecutor = "containerd-shim-spin"
 )
 
 // global variables available to all sub-commands

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -12,6 +12,11 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth" // required for k8s client auth
 )
 
+// global constants
+const (
+	default_spin_app_executor = "containerd-shim-spin"
+)
+
 // global variables available to all sub-commands
 var (
 	appNameFromCurrentDirContext = ""

--- a/pkg/cmd/scaffold.go
+++ b/pkg/cmd/scaffold.go
@@ -188,7 +188,7 @@ var scaffoldCmd = &cobra.Command{
 		}
 
 		if scaffoldOpts.output != "" {
-			err = os.WriteFile(scaffoldOpts.output, content, 0600)
+			err = os.WriteFile(scaffoldOpts.output, content, 0o600)
 			if err != nil {
 				return err
 			}
@@ -335,7 +335,7 @@ func init() {
 	scaffoldCmd.Flags().Int32Var(&scaffoldOpts.targetCPUUtilizationPercentage, "autoscaler-target-cpu-utilization", 60, "The target CPU utilization percentage to maintain across all pods")
 	scaffoldCmd.Flags().Int32Var(&scaffoldOpts.targetMemoryUtilizationPercentage, "autoscaler-target-memory-utilization", 60, "The target memory utilization percentage to maintain across all pods")
 	scaffoldCmd.Flags().StringVar(&scaffoldOpts.autoscaler, "autoscaler", "", "The autoscaler to use. Valid values are 'hpa' and 'keda'")
-	scaffoldCmd.Flags().StringVar(&scaffoldOpts.executor, "executor", "containerd-shim-spin", "The executor used to run the application")
+	scaffoldCmd.Flags().StringVar(&scaffoldOpts.executor, "executor", default_spin_app_executor, "The executor used to run the application")
 	scaffoldCmd.Flags().StringVar(&scaffoldOpts.cpuLimit, "cpu-limit", "", "The maximum amount of CPU resource units the application is allowed to use")
 	scaffoldCmd.Flags().StringVar(&scaffoldOpts.cpuRequest, "cpu-request", "", "The amount of CPU resource units requested by the application. Used to determine which node the application will run on")
 	scaffoldCmd.Flags().StringVar(&scaffoldOpts.memoryLimit, "memory-limit", "", "The maximum amount of memory the application is allowed to use")

--- a/pkg/cmd/scaffold.go
+++ b/pkg/cmd/scaffold.go
@@ -335,7 +335,7 @@ func init() {
 	scaffoldCmd.Flags().Int32Var(&scaffoldOpts.targetCPUUtilizationPercentage, "autoscaler-target-cpu-utilization", 60, "The target CPU utilization percentage to maintain across all pods")
 	scaffoldCmd.Flags().Int32Var(&scaffoldOpts.targetMemoryUtilizationPercentage, "autoscaler-target-memory-utilization", 60, "The target memory utilization percentage to maintain across all pods")
 	scaffoldCmd.Flags().StringVar(&scaffoldOpts.autoscaler, "autoscaler", "", "The autoscaler to use. Valid values are 'hpa' and 'keda'")
-	scaffoldCmd.Flags().StringVar(&scaffoldOpts.executor, "executor", default_spin_app_executor, "The executor used to run the application")
+	scaffoldCmd.Flags().StringVar(&scaffoldOpts.executor, "executor", defaultSpinAppExecutor, "The executor used to run the application")
 	scaffoldCmd.Flags().StringVar(&scaffoldOpts.cpuLimit, "cpu-limit", "", "The maximum amount of CPU resource units the application is allowed to use")
 	scaffoldCmd.Flags().StringVar(&scaffoldOpts.cpuRequest, "cpu-request", "", "The amount of CPU resource units requested by the application. Used to determine which node the application will run on")
 	scaffoldCmd.Flags().StringVar(&scaffoldOpts.memoryLimit, "memory-limit", "", "The maximum amount of memory the application is allowed to use")


### PR DESCRIPTION
Turn the previously experimental command into a stable command. 

This allows Spin users setting `SPIN_DEPLOY_PLUGIN` to `kube`, so that they can deploy straight to their Kubernetes cluster with SpinKube using the shortcut `spin deploy`.

The following changes are part of this PR:

- Add `--executor` flag to allow users specifying the desired `SpinAppExecutor`
- Introduce private constant `defaultSpinAppExecutor` to reuse `containerd-shim-spin` across `deploy` and `scaffold` command
- Print updated API group when deployment succeeded

Additionally, I had to bump `golangci-lint` to a newer version because `setup-go` installs latest golang... which is too new for the previously specified version of `golangci-lint`

closes #128